### PR TITLE
Handle CLISP, fail for unknown implementations

### DIFF
--- a/src/typespecs.lisp
+++ b/src/typespecs.lisp
@@ -7,6 +7,9 @@
         #+sbcl (return (sb-ext:valid-type-specifier-p type-specifier))
         #+openmcl (return (ccl:type-specifier-p type-specifier))
         #+ecl (return (c::valid-type-specifier type-specifier))
+        #+clisp (return (null
+                         (nth-value 1 (ignore-errors
+                                       (ext:type-expand type-specifier)))))
         (error "Not implemented"))))
 
 (defun type-expand (type-specifier &optional env)

--- a/src/typespecs.lisp
+++ b/src/typespecs.lisp
@@ -3,9 +3,11 @@
 (defun type-specifier-p (type-specifier)
   "Returns true if TYPE-SPECIFIER is a valid type specfiier."
   (or (documentation type-specifier 'type)
-      #+sbcl (sb-ext:valid-type-specifier-p type-specifier)
-      #+openmcl (ccl:type-specifier-p type-specifier)
-      #+ecl (c::valid-type-specifier type-specifier)))
+      (block nil
+        #+sbcl (return (sb-ext:valid-type-specifier-p type-specifier))
+        #+openmcl (return (ccl:type-specifier-p type-specifier))
+        #+ecl (return (c::valid-type-specifier type-specifier))
+        (error "Not implemented"))))
 
 (defun type-expand (type-specifier &optional env)
   "Expand TYPE-SPECIFIER in the lexical environment ENV."

--- a/src/typespecs.lisp
+++ b/src/typespecs.lisp
@@ -10,10 +10,13 @@
         #+clisp (return (null
                          (nth-value 1 (ignore-errors
                                        (ext:type-expand type-specifier)))))
-        (error "Not implemented"))))
+        (error "TYPE-SPECIFIER-P not available for this implementation"))))
 
 (defun type-expand (type-specifier &optional env)
   "Expand TYPE-SPECIFIER in the lexical environment ENV."
-  #+sbcl (sb-ext::typexpand type-specifier env)
-  #+openmcl (ccl::type-expand type-specifier env)
-  #-(or sbcl openmcl) type-specifier)
+  (or (block nil
+        #+sbcl (return (sb-ext::typexpand type-specifier env))
+        #+openmcl (return (ccl::type-expand type-specifier env))
+        #+clisp (return (ext:type-expand type-specifier)))
+      (prog1 type-specifier
+        (warn "TYPE-EXPAND not available for this implementation"))))


### PR DESCRIPTION
- Signal an error if `type-specifier-p` is not available on current implementation.
- Add code for CLISP